### PR TITLE
add ability to add custom widget in settings.py

### DIFF
--- a/django_ckeditor_5/widgets.py
+++ b/django_ckeditor_5/widgets.py
@@ -11,7 +11,7 @@ DEFAULT_CONFIG = {
 }
 
 class CKEditor5Widget(forms.Widget):
-    template_name = 'django_ckeditor_5/widget.html'
+    template_name = getattr(settings, 'CKEDITOR_5_CUSTOM_WIDGET', 'django_ckeditor_5/widget.html')
 
     def __init__(self, config_name='default', attrs=None):
         self._config_errors = []


### PR DESCRIPTION
Currently if you use the widget in Django admin you will notice that when using mobile, the widget does not display correctly. I have to customise the widget to fix this but I have to do it with a custom widget.
The change will allow adding a custom widget if necessary by defining CKEDITOR_5_CUSTOM_WIDGET in settings.py in your project.