### PR TITLE
Add example section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,8 +178,11 @@ Includes the following ckeditor5 plugins:
             SourceEditing,
             GeneralHtmlSupport
 
-Example of using a widget in a form:
+Examples
+-----------
 
+Example of using a widget in a form:
+^^^^^^^^^^^
   .. code-block:: python
 
       from django import forms
@@ -206,7 +209,7 @@ Example of using a widget in a form:
 
 
 Custom storage example:
-
+^^^^^^^^^^^
   .. code-block:: python
 
       import os
@@ -223,6 +226,7 @@ Custom storage example:
           base_url = urljoin(settings.MEDIA_URL, "django_ckeditor_5/")
 
 Using from github:
+^^^^^^^^^^^
   .. code-block:: bash
 
     cd your_root_project
@@ -232,3 +236,16 @@ Using from github:
     yarn run prod
     cd your_root_project
     python manage.py collectstatic
+    
+Example Sharing content styles between front-end and back-end
+^^^^^^^^^^^
+To apply ckeditor5 styling outside of the editor, download content.styles.css from the official ckeditor5 docs and include it as a styleshet within your HTML template. You will need to add the ck-content class to the container of your content for the styles to be applied.
+`<https://ckeditor.com/docs/ckeditor5/latest/installation/advanced/content-styles.html#sharing-content-styles-between-frontend-and-backend>`_
+
+.. code-block:: html
+
+   <link rel="stylesheet" href="path/to/assets/content-styles.css" type="text/css">
+   ...
+   <div class="ck-content">
+   <p>ckeditor content</p>
+   </div>


### PR DESCRIPTION
Add an example subsection and a new subsubsection example showing how to share ckeditor5 styles between the front and backend.

Closes
https://github.com/hvlads/django-ckeditor-5/issues/78