### PR TITLE
Fix issue initialising empty (placeholder) forms and add compatilibilty with django-nested-admin

### DIFF
--- a/django_ckeditor_5/static/django_ckeditor_5/app.js
+++ b/django_ckeditor_5/static/django_ckeditor_5/app.js
@@ -29,10 +29,10 @@ function createEditors() {
         }
         allEditors[i].nextSibling.remove();
         const upload_url = document.getElementById(
-            `ck-editor-5-upload-url-${script_id}`
+            `${script_id}-ck-editor-5-upload-url`
         ).getAttribute('data-upload-url');
         const csrf_cookie_name = document.getElementById(
-            `ck-editor-5-upload-url-${script_id}`
+            `${script_id}-ck-editor-5-upload-url`
         ).getAttribute('data-csrf_cookie_name');
         document.querySelector(`[for$="${allEditors[i].id}"]`).style.float = 'none';
         const config = JSON.parse(
@@ -55,7 +55,7 @@ function createEditors() {
         ).then(editor => {
             if (editor.plugins.has('WordCount')) {
                 const wordCountPlugin = editor.plugins.get('WordCount');
-                const wordCountWrapper = document.getElementById(`word-count-${script_id}`);
+                const wordCountWrapper = document.getElementById(`${script_id}-word-count`);
                 wordCountWrapper.innerHTML = '';
                 wordCountWrapper.appendChild(wordCountPlugin.wordCountContainer);
             }

--- a/django_ckeditor_5/static/django_ckeditor_5/app.js
+++ b/django_ckeditor_5/static/django_ckeditor_5/app.js
@@ -3,7 +3,6 @@ import './src/override-django.css';
 
 
 let editors = [];
-let editorsIds = [];
 
 function getCookie(name) {
     let cookieValue = null;
@@ -23,10 +22,13 @@ function getCookie(name) {
 function createEditors() {
     const allEditors = document.querySelectorAll('.django_ckeditor_5');
     for (let i = 0; i < allEditors.length; ++i) {
-        const script_id = `${allEditors[i].id}_script`;
-        if (editorsIds.indexOf(script_id) !== -1) {
+        if (
+            allEditors[i].id.indexOf('__prefix__') !== -1 ||
+            allEditors[i].getAttribute('data-processed') === '1'
+        ) {
             continue;
         }
+        const script_id = `${allEditors[i].id}_script`;
         allEditors[i].nextSibling.remove();
         const upload_url = document.getElementById(
             `${script_id}-ck-editor-5-upload-url`
@@ -63,7 +65,7 @@ function createEditors() {
         }).catch(error => {
             console.error((error));
         });
-        editorsIds.push(script_id);
+        allEditors[i].setAttribute('data-processed', '1');
     }
     window.editors = editors;
     window.ClassicEditor = ClassicEditor;

--- a/django_ckeditor_5/templates/django_ckeditor_5/widget.html
+++ b/django_ckeditor_5/templates/django_ckeditor_5/widget.html
@@ -1,9 +1,9 @@
 <textarea  name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
 {% if widget.value %}{{ widget.value }}{% endif %}</textarea>
-<div class="word-count" id="word-count-{{script_id}}"></div>
+<span class="word-count" id="{{script_id}}-word-count"></span>
 {% if errors %}
 {{ errors }}
 {% endif %}
-<input type="hidden" id="ck-editor-5-upload-url-{{script_id}}" data-upload-url="{{upload_url}}" data-csrf_cookie_name="{{ csrf_cookie_name }}">
+<input type="hidden" id="{{script_id}}-ck-editor-5-upload-url" data-upload-url="{{upload_url}}" data-csrf_cookie_name="{{ csrf_cookie_name }}">
 
-{{ config|json_script:script_id}}
+<span id="{{script_id}}">{{ config|json_script}}</span>


### PR DESCRIPTION
Hi @hvlads,

This fixes a bug in the way the initialisation script works. The script initialises the empty forms, and also does not initialise the form when a new row gets added, removed, then added again. This happens because it is storing the script id in the module variable `editorIds`. So what happens is,

1. The page loads
2. All ckeditor-5 fields are initialised _**including the empty (`__prefix__`) forms**_
3. The user clicks "Add another INLINE_NAME" and that field gets initialised (let's assume this would then have the `script_id` of `id_inlinemodel-3-ckefieldname_script`
4. The user then removes this new row by clicking the X
5. The user then clicks "Add another INLINE_NAME"
6. This is where the bug occurs: the script id of `id_inlinemodel-3-ckefieldname_script` gets added again, but the initialisation script thinks it has already initialised `id_inlinemodel-3-ckefieldname_script` which is stored in `editorIds`, so it skips the initialisation step

Because the empty form has already been initialised, the editor appears to be working and hence this sneaky bug gets hidden. But it emerges in more advanced usecases.

To rectify this issue, I've modified the script so that it no longer initialises empty forms (`allEditors[i].id.indexOf('__prefix__') !== -1`) and then it adds a data attribute `data-processed=1` after initialisation and skips initialisation if that data attribute is already set instead of using the `editorIds` module variable. 


This PR also includes the changes needed to add support for theatlantic/django-nested-admin. I understand not wanting to add compatibility with every django package out there - that would cause a real headache. But as you can see this is a very minimal change, django-nested-admin is very popular (it has [over 600 stars on Github](https://github.com/theatlantic/django-nested-admin) & over [174K downloads last month](https://pypistats.org/packages/django-nested-admin)) and you indicated in #137 that you'd like to make the code universal, and this PR achieves that.

Let me know if you'd like me to make any changes to this PR. 🙂

Cheers,
Nat