### PR TITLE
Restore compatibility with django-nested-admin

### DIFF
--- a/django_ckeditor_5/static/django_ckeditor_5/app.js
+++ b/django_ckeditor_5/static/django_ckeditor_5/app.js
@@ -42,7 +42,7 @@ function createEditors() {
         }
 
         const config = JSON.parse(
-            document.getElementById(script_id).textContent,
+            document.getElementById(`${script_id}-span`).textContent,
             (key, value) => {
                 if (value.toString().includes('/')) {
                     return new RegExp(value.replaceAll('/', ''));

--- a/django_ckeditor_5/templates/django_ckeditor_5/widget.html
+++ b/django_ckeditor_5/templates/django_ckeditor_5/widget.html
@@ -6,4 +6,4 @@
 {% endif %}
 <input type="hidden" id="{{script_id}}-ck-editor-5-upload-url" data-upload-url="{{upload_url}}" data-csrf_cookie_name="{{ csrf_cookie_name }}">
 
-<span>{{ config|json_script:script_id }}</span>
+<span id="{{script_id}}-span">{{ config|json_script:script_id }}</span>


### PR DESCRIPTION
@hvlads This tiny PR restores compatibility with django-nested-admin while maintaining backwards compatibility with django <4.1.

The problem with not having the span not having an id, is that for security reasons, django-nested-admin doesn't update the id for script tags when adding another row.