### PR TITLE
improve handling of config values containing slashes

### DIFF
--- a/django_ckeditor_5/static/django_ckeditor_5/app.js
+++ b/django_ckeditor_5/static/django_ckeditor_5/app.js
@@ -44,8 +44,10 @@ function createEditors() {
         const config = JSON.parse(
             document.getElementById(`${script_id}-span`).textContent,
             (key, value) => {
-                if (value.toString().includes('/')) {
-                    return new RegExp(value.replaceAll('/', ''));
+                var match = value.toString().match(new RegExp('^/(.*?)/([gimy]*)$'));
+                if (match) {
+                   var regex = new RegExp(match[1], match[2]);
+                   return regex;
                 }
                 return value;
             }

--- a/example/blog/blog/settings.py
+++ b/example/blog/blog/settings.py
@@ -281,6 +281,7 @@ CKEDITOR_5_CONFIGS = {
                 "reversed": True,
             },
         },
+        "link": {"defaultProtocol": "https://"},
         "htmlSupport": {
             "allow": [
                 {"name": "/.*/", "attributes": True, "classes": True, "styles": True},


### PR DESCRIPTION
Use a regexp to test if a value might be a valid regexp. This fixes config values ending up broken if they contain slashes but are not actually a regexp.

One such example is: "link": {"defaultProtocol": "https://"}