### PR TITLE
Readme updated to include a widget example containing the form.media attribute

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,6 +226,21 @@ Example of using a widget in a form:
                     )
                 }
 
+Example of using a widget in a template:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  .. code-block:: python
+
+    {% extends 'base.html' %}
+    {% block header %}
+        {{ form.media }} # Required for styling/js to make ckeditor5 work
+    {% endblock %}
+    {% block content %}
+        <form method="POST">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <input type="submit" value="Submit article">
+        </form>
+    {% endblock %}
 
 Custom storage example:
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Thanks for building this! This will add a lot of functionality to my future apps. In order to make this widget work, the form needs to have a form.media tag. A lot of time could be saved with this information in the README. 

I'm not sure if the exampled I copied from the example project is the best way to go given all of the template tags, but it emphasizes the need for form.media somewhere in a form.

Thanks!