### PR TITLE
return 400 response code with error message

### DIFF
--- a/django_ckeditor_5/views.py
+++ b/django_ckeditor_5/views.py
@@ -70,7 +70,7 @@ def upload_file(request):
             try:
                 image_verify(request.FILES['upload'])
             except NoImageException as ex:
-                return JsonResponse({"error": {"message": f"{ex}"}})
+                return JsonResponse({"error": {"message": f"{ex}"}}, status=400)
         if form.is_valid():
             url = handle_uploaded_file(request.FILES["upload"])
             return JsonResponse({"url": url})


### PR DESCRIPTION
For debugging and UX purposes, it might be more user friendly to respond with an error status code in the case that the response contains an error message.