### PR TITLE
Use the arrow notation to call the createEditors() function on `form…

### DIFF
--- a/django_ckeditor_5/static/django_ckeditor_5/app.js
+++ b/django_ckeditor_5/static/django_ckeditor_5/app.js
@@ -156,7 +156,7 @@ document.addEventListener("DOMContentLoaded", () => {
     createEditors();
 
     if (typeof django === "object" && django.jQuery) {
-        django.jQuery(document).on("formset:added", createEditors);
+        django.jQuery(document).on("formset:added", () => {createEditors()});
     }
 
     const observer = new MutationObserver((mutations) => {


### PR DESCRIPTION
When `formset:added` event is called, the event is passed implicitly through the call:
```javascript
django.jQuery(document).on("formset:added", createEditors);
```

which cause a  TypeError on call:
```javascript
Uncaught TypeError: e.matches is not a function
```
... as the event object does not have the `matches` method.

This PR changes the event handler to:
```javascript
django.jQuery(document).on("formset:added", () => {createEditors()});
```  

... which forces the createEditors function to be called without parameter.

This fixes issue #253 

Thanks !