### PR TITLE
Add Kbd plugin 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Django CKEditor 5 
+Django CKEditor 5
 ==================
 
    CKEditor 5 for Django >= 2.0
@@ -7,7 +7,7 @@ Quick start
 -----------
 
  .. code-block:: bash
- 
+
         pip install django-ckeditor-5
 
 1. Add "django_ckeditor_5" to your INSTALLED_APPS in your `project/settings.py` like this:
@@ -57,11 +57,11 @@ Quick start
 
       CKEDITOR_5_CUSTOM_CSS = 'path_to.css' # optional
       CKEDITOR_5_FILE_STORAGE = "path_to_storage.CustomStorage" # optional
-      CKEDITOR_5_CONFIGS = { 
+      CKEDITOR_5_CONFIGS = {
         'default': {
             'toolbar': ['heading', '|', 'bold', 'italic', 'link',
                         'bulletedList', 'numberedList', 'blockQuote', 'imageUpload', ],
-    
+
         },
         'extends': {
             'blockToolbar': [
@@ -86,7 +86,7 @@ Quick start
                     'alignRight',
                     'alignCenter',
                 ]
-    
+
             },
             'table': {
                 'contentToolbar': [ 'tableColumn', 'tableRow', 'mergeTableCells',
@@ -122,15 +122,15 @@ Quick start
     CKEDITOR_5_FILE_UPLOAD_PERMISSION = "staff"  # Possible values: "staff", "authenticated", "any"
 
 3. Include the app URLconf in your `project/urls.py` like this:
- 
+
   .. code-block:: python
 
        from django.conf import settings
        from django.conf.urls.static import static
-       
+
        # [ ... ]
-       
-       urlpatterns += [ 
+
+       urlpatterns += [
            path("ckeditor5/", include('django_ckeditor_5.urls')),
        ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
@@ -154,8 +154,8 @@ This allows users to customize the upload file logic by specifying their own vie
 
 
 
-    
-    
+
+
 4. Add to your `project/models.py`:
 
   .. code-block:: python
@@ -163,12 +163,12 @@ This allows users to customize the upload file logic by specifying their own vie
 
         from django.db import models
         from django_ckeditor_5.fields import CKEditor5Field
-        
-        
+
+
         class Article(models.Model):
             title=models.CharField('Title', max_length=200)
             text=CKEditor5Field('Text', config_name='extends')
-            
+
 
 Includes the following ckeditor5 plugins:
 
@@ -223,7 +223,8 @@ Includes the following ckeditor5 plugins:
             ShowBlocks,
             SelectAll,
             FindAndReplace,
-            FullScreen
+            FullScreen,
+            Kbd
 
 
 Examples
@@ -410,7 +411,7 @@ Installing from GitHub:
     yarn run prod
     cd your_root_project
     python manage.py collectstatic
-    
+
 Example Sharing content styles between front-end and back-end:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 To apply ckeditor5 styling outside of the editor, download content.styles.css from the official ckeditor5 docs and include it as a styleshet within your HTML template. You will need to add the ck-content class to the container of your content for the styles to be applied.

--- a/django_ckeditor_5/package-lock.json
+++ b/django_ckeditor_5/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "django_ckeditor_5",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "django_ckeditor_5",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@ckeditor/ckeditor5-adapter-ckfinder": "^43.2.0",
@@ -47,6 +47,7 @@
         "@ckeditor/ckeditor5-upload": "^43.2.0",
         "@ckeditor/ckeditor5-word-count": "^43.2.0",
         "@liqd/ckeditor5-file-uploader": "github:liqd/ckeditor5-file-uploader#v0.0.5",
+        "@mlewand/ckeditor5-keyboard-marker": "^1.0.3",
         "@pikulinpw/ckeditor5-fullscreen": "^1.0.1"
       },
       "devDependencies": {
@@ -1693,6 +1694,21 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
+    },
+    "node_modules/@mlewand/ckeditor5-keyboard-marker": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@mlewand/ckeditor5-keyboard-marker/-/ckeditor5-keyboard-marker-1.0.3.tgz",
+      "integrity": "sha512-r4VazctFHYT7nFdJzq0ncxd2GEmwtAq4BjaP6sUOJy6t+sPNYNm9YyaNMOk5RuXoZR/VAfsUQyvlT20/iKoISQ==",
+      "license": "GPL-3.0",
+      "engines": {
+        "node": ">=10.0.0",
+        "npm": ">=5.7.1"
+      },
+      "peerDependencies": {
+        "@ckeditor/ckeditor5-basic-styles": ">=19.0.0",
+        "@ckeditor/ckeditor5-core": ">=19.0.0",
+        "@ckeditor/ckeditor5-ui": ">=19.0.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/django_ckeditor_5/package.json
+++ b/django_ckeditor_5/package.json
@@ -48,8 +48,9 @@
     "@ckeditor/ckeditor5-ui": "^43.2.0",
     "@ckeditor/ckeditor5-upload": "^43.2.0",
     "@ckeditor/ckeditor5-word-count": "^43.2.0",
-    "@pikulinpw/ckeditor5-fullscreen": "^1.0.1",
-    "@liqd/ckeditor5-file-uploader": "github:liqd/ckeditor5-file-uploader#v0.0.5"
+    "@liqd/ckeditor5-file-uploader": "github:liqd/ckeditor5-file-uploader#v0.0.5",
+    "@mlewand/ckeditor5-keyboard-marker": "^1.0.3",
+    "@pikulinpw/ckeditor5-fullscreen": "^1.0.1"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-core": "^43.2.0",

--- a/django_ckeditor_5/static/django_ckeditor_5/src/ckeditor.js
+++ b/django_ckeditor_5/static/django_ckeditor_5/src/ckeditor.js
@@ -53,6 +53,7 @@ import { ShowBlocks } from '@ckeditor/ckeditor5-show-blocks';
 import { SelectAll } from '@ckeditor/ckeditor5-select-all';
 import { FindAndReplace } from '@ckeditor/ckeditor5-find-and-replace';
 import FullScreen from '@pikulinpw/ckeditor5-fullscreen';
+import Kbd from '@mlewand/ckeditor5-keyboard-marker/src/Kbd';
 
 export default class ClassicEditor extends ClassicEditorBase {
 }
@@ -110,5 +111,6 @@ ClassicEditor.builtinPlugins = [
     ShowBlocks,
     SelectAll,
     FindAndReplace,
-    FullScreen
+    FullScreen,
+    Kbd
 ];


### PR DESCRIPTION
This adds the [mlewand/ckeditor5-keyboard-marker](https://github.com/mlewand/ckeditor5-keyboard-marker) plugin (tested with current tag 1.0.3). It adds support for the \<kbd> tag. It currently does not add CSS styles for the editor.