### PR TITLE
Change Django dependency to 2.0+. Fixes: #285

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
     ]
 
 dependencies = [
-  'Django >= 5.1.6',
+  'Django >= 2.0',
   'Pillow',
 ]
 


### PR DESCRIPTION
This changes dependency of Django to 2.0+ so it can be installed with Django 4 and lower.