### PR TITLE
Fix #271: Clean empty HTML content for optional CKEditor5 fields

### DIFF
--- a/django_ckeditor_5/fields.py
+++ b/django_ckeditor_5/fields.py
@@ -1,3 +1,6 @@
+import html
+import re
+
 from django.db import models
 
 from .widgets import CKEditor5Widget
@@ -19,3 +22,22 @@ class CKEditor5Field(models.Field):
                 **kwargs,
             },
         )
+
+    @staticmethod
+    def _is_empty_html(value):
+        """Check if HTML content is effectively empty (e.g. '<p>&nbsp;</p>')."""
+        if not value:
+            return True
+        if re.search(
+            r"<(img|video|audio|iframe|embed|object|source)\b", value, re.IGNORECASE
+        ):
+            return False
+        text = html.unescape(value)
+        text = re.sub(r"<[^>]+>", "", text)
+        return not text.strip()
+
+    def get_prep_value(self, value):
+        value = super().get_prep_value(value)
+        if self.blank and value and self._is_empty_html(value):
+            return ""
+        return value

--- a/example/blog/conftest.py
+++ b/example/blog/conftest.py
@@ -20,6 +20,11 @@ def ckeditor5_field():
 
 
 @pytest.fixture
+def ckeditor5_blank_field():
+    return CKEditor5Field(blank=True)
+
+
+@pytest.fixture
 def upload_file_form():
     return UploadFileForm()
 

--- a/example/blog/tests/test_fields.py
+++ b/example/blog/tests/test_fields.py
@@ -1,3 +1,4 @@
+from django_ckeditor_5.fields import CKEditor5Field
 from django_ckeditor_5.widgets import CKEditor5Widget
 
 
@@ -9,3 +10,28 @@ def test_ckeditor5_field_formfield(ckeditor5_field):
     formfield = ckeditor5_field.formfield()
     assert formfield.max_length == ckeditor5_field.max_length
     assert isinstance(formfield.widget, CKEditor5Widget)
+
+
+def test_is_empty_html_detects_empty_content():
+    """CKEditor5 empty patterns like <p>&nbsp;</p> should be detected as empty."""
+    assert CKEditor5Field._is_empty_html("<p>&nbsp;</p>") is True
+
+
+def test_is_empty_html_detects_real_content():
+    """HTML with actual content should not be detected as empty."""
+    assert CKEditor5Field._is_empty_html("<p>Hello</p>") is False
+
+
+def test_blank_field_cleans_empty_html(ckeditor5_blank_field):
+    """Field with blank=True should convert empty HTML to empty string."""
+    assert ckeditor5_blank_field.get_prep_value("<p>&nbsp;</p>") == ""
+
+
+def test_blank_field_preserves_content(ckeditor5_blank_field):
+    """Field with blank=True should preserve actual content."""
+    assert ckeditor5_blank_field.get_prep_value("<p>Hello</p>") == "<p>Hello</p>"
+
+
+def test_required_field_preserves_empty_html(ckeditor5_field):
+    """Field with blank=False should preserve empty HTML as-is."""
+    assert ckeditor5_field.get_prep_value("<p>&nbsp;</p>") == "<p>&nbsp;</p>"


### PR DESCRIPTION
## Summary
- Fix issue where `CKEditor5Field(blank=True)` stores `<p>&nbsp;</p>` instead of empty string
- Added `get_prep_value()` to clean empty HTML patterns before saving to database
- Only affects fields with `blank=True`, preserves existing behavior for required fields

## Problem
When a CKEditor5 field with `blank=True` is left empty, CKEditor5 generates `<p>&nbsp;</p>`. This causes `if field_value:` checks to incorrectly evaluate as `True`.

## Solution
Added `_is_empty_html()` static method and `get_prep_value()` override to detect and clean empty HTML patterns like:
- `<p>&nbsp;</p>`
- `<p></p>`
- `<p><br></p>`

Media elements (img, video, audio, iframe, etc.) are preserved.

## Test plan
- [x] Added 5 new test cases
- [x] All 20 tests passing
- [x] Black formatting check passed
- [x] Ruff lint check passed

Fixes #271