### PR TITLE
fix: prevent Django admin dark mode from breaking editor text color

### DIFF
--- a/django_ckeditor_5/static/django_ckeditor_5/src/override-django.css
+++ b/django_ckeditor_5/static/django_ckeditor_5/src/override-django.css
@@ -14,6 +14,8 @@
 
 .ck.ck-content.ck-editor__editable {
     min-height: 300px;
+    color: var(--ck-color-text);
+    background: var(--ck-color-base-background, #fff);
 }
 
 .ck h2 {


### PR DESCRIPTION
## Summary
- When Django admin is in dark mode, `color: white` on body cascades into the CKEditor content area, making text invisible (white on white).
- Explicitly set `color` and `background` on `.ck-content` using CKEditor's own CSS variables (`--ck-color-text` and `--ck-color-base-background`), breaking the inheritance chain.
- Custom dark themes via `CKEDITOR_5_CUSTOM_CSS` still work — they override the same variables.

Closes #305

## Test plan
- [x] Open Django admin with `prefers-color-scheme: dark` — editor text should be dark on white background
- [x] Switch to light mode — no visual change (was already working)
- [x] If using `CKEDITOR_5_CUSTOM_CSS` with dark CKEditor variables — editor should render with custom dark theme